### PR TITLE
Some improvements to group table

### DIFF
--- a/billchop-fe/src/components/AddBillModal.tsx
+++ b/billchop-fe/src/components/AddBillModal.tsx
@@ -70,7 +70,7 @@ export default class AddBillModal extends React.Component<
               />
             </Form.Row>
             <Form.Row>
-              <Form.Label className="mt-2">Total amount:</Form.Label>
+              <Form.Label className="mt-2">Total amount(€):</Form.Label>
               <Form.Control
                 placeholder="Enter the total amount of the bill"
                 onChange={(e) =>

--- a/billchop-fe/src/components/BillsListAccordion.tsx
+++ b/billchop-fe/src/components/BillsListAccordion.tsx
@@ -37,7 +37,7 @@ export default class BillsListAccordion extends React.Component<
             <img className="mr-2" src={BillIcon} height="32px" width="32px" alt="Bill icon" />
             <div className="ml-2 d-flex justify-content-between align-items-center flex-grow-1">
               <div><span style={{ fontWeight: 500 }}>{bill.Name}</span></div>
-              <div>{toEuros(bill.Total)} ({/* TODO add date */})</div>
+              <div>{toEuros(bill.Total)} {/* TODO add date */}</div>
             </div>
           </Accordion.Toggle>
           <Accordion.Collapse eventKey={bill.Id}>

--- a/billchop-fe/src/components/BillsListAccordion.tsx
+++ b/billchop-fe/src/components/BillsListAccordion.tsx
@@ -36,7 +36,7 @@ export default class BillsListAccordion extends React.Component<
             <img className="mr-2" src={BillIcon} height="32px" width="32px" alt="Bill icon" />
             <div className="ml-2 d-flex justify-content-between align-items-center flex-grow-1">
               <div><span style={{ fontWeight: 500 }}>{bill.Name}</span> {/*TODO add date here*/}</div>
-              <div>{bill.Total.toFixed(2)}</div>
+              <div>{toEuros(bill.Total)}</div>
             </div>
           </Accordion.Toggle>
           <Accordion.Collapse eventKey={bill.Id}>

--- a/billchop-fe/src/components/BillsListAccordion.tsx
+++ b/billchop-fe/src/components/BillsListAccordion.tsx
@@ -35,9 +35,8 @@ export default class BillsListAccordion extends React.Component<
           <Accordion.Toggle className="bill-list-accordion" as={Card.Header} eventKey={bill.Id}>
             <img className="mr-2" src={BillIcon} height="32px" width="32px" alt="Bill icon" />
             <div className="ml-2 d-flex justify-content-between align-items-center flex-grow-1">
-              <div>{bill.Name}</div>
+              <div><span style={{ fontWeight: 500 }}>{bill.Name}</span> {/*TODO add date here*/}</div>
               <div>{bill.Total.toFixed(2)}</div>
-              {/* TODO Add date */}
             </div>
           </Accordion.Toggle>
           <Accordion.Collapse eventKey={bill.Id}>

--- a/billchop-fe/src/components/BillsListAccordion.tsx
+++ b/billchop-fe/src/components/BillsListAccordion.tsx
@@ -36,8 +36,8 @@ export default class BillsListAccordion extends React.Component<
           <Accordion.Toggle className="bill-list-accordion" as={Card.Header} eventKey={bill.Id}>
             <img className="mr-2" src={BillIcon} height="32px" width="32px" alt="Bill icon" />
             <div className="ml-2 d-flex justify-content-between align-items-center flex-grow-1">
-              <div><span style={{ fontWeight: 500 }}>{bill.Name}</span> {/*TODO add date here*/}</div>
-              <div>{toEuros(bill.Total)}</div>
+              <div><span style={{ fontWeight: 500 }}>{bill.Name}</span></div>
+              <div>{toEuros(bill.Total)} ({/* TODO add date */})</div>
             </div>
           </Accordion.Toggle>
           <Accordion.Collapse eventKey={bill.Id}>

--- a/billchop-fe/src/components/BillsListAccordion.tsx
+++ b/billchop-fe/src/components/BillsListAccordion.tsx
@@ -6,6 +6,7 @@ import BillIcon from "../assets/bill-icon.svg";
 import Dictionary from "../util/Dictionary";
 import GroupTable from "./GroupTable";
 import "../styles/bill-list-accordion.css";
+import toEuros from "../util/Currency";
 
 export interface IBillsListAccordionProps {
   group: Group;

--- a/billchop-fe/src/components/BillsListAccordion.tsx
+++ b/billchop-fe/src/components/BillsListAccordion.tsx
@@ -46,6 +46,7 @@ export default class BillsListAccordion extends React.Component<
                 group={group}
                 expenseAmounts={this.generateExpenseAmounts(bill)}
                 showMembersOnlyWithExpenses
+                loanerId={bill.Loaner.Id}
               />
             </Card.Body>
           </Accordion.Collapse>

--- a/billchop-fe/src/components/GroupTable.tsx
+++ b/billchop-fe/src/components/GroupTable.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import Table from "react-bootstrap/Table";
+import UserContext from "../backend/helpers/UserContext";
 import Group from "../backend/models/Group";
 import Dictionary from "../util/Dictionary";
 
@@ -8,6 +9,7 @@ export interface IGroupTableProps {
   expenseAmounts: Dictionary<number>;
   colorCode?: boolean;
   showMembersOnlyWithExpenses?: boolean;
+  loanerId?: string;
 }
 
 export default class GroupTable extends React.Component<IGroupTableProps> {
@@ -30,9 +32,11 @@ export default class GroupTable extends React.Component<IGroupTableProps> {
       group,
       expenseAmounts,
       showMembersOnlyWithExpenses,
+      loanerId,
     } = this.props;
 
     let groupUsers = group.Users;
+    const currentUserId = UserContext.authenticatedUser.Id;
 
     if (showMembersOnlyWithExpenses && expenseAmounts !== undefined) {
       groupUsers = group.Users?.filter((user) => {
@@ -41,19 +45,20 @@ export default class GroupTable extends React.Component<IGroupTableProps> {
     }
 
     tableContent.push(
-      groupUsers.map((user) => {
-        const expense = expenseAmounts[user.Id]
-          ? expenseAmounts[user.Id].toFixed(2).replace("-0.00", "0.00")
-          : "0.00";
-        return (
-          <tr key={user.Id}>
-            <td>{user.Name}</td>
-            <td style={this.getExpenseStyling(expenseAmounts[user.Id])}>
-              {expense}
-            </td>
-          </tr>
-        );
-      }),
+      groupUsers.sort((user) => user.Id === currentUserId ? -1 : 0)
+        .map((user) => {
+          const expense = expenseAmounts[user.Id]
+            ? expenseAmounts[user.Id].toFixed(2).replace("-0.00", "0.00")
+            : "0.00";
+          return (
+            <tr key={user.Id}>
+              <td>{user.Id === UserContext.authenticatedUser.Id ? "You" : user.Name} {user.Id === loanerId && "(Payer)"}</td>
+              <td style={this.getExpenseStyling(expenseAmounts[user.Id])}>
+                {expense}
+              </td>
+            </tr>
+          );
+        }),
     );
     return tableContent;
   };

--- a/billchop-fe/src/components/GroupTable.tsx
+++ b/billchop-fe/src/components/GroupTable.tsx
@@ -49,7 +49,7 @@ export default class GroupTable extends React.Component<IGroupTableProps> {
       groupUsers.sort((user) => user.Id === currentUserId ? -1 : 0)
         .map((user) => {
           const expense = expenseAmounts[user.Id]
-            ? toEuros(expenseAmounts[user.Id]).replace("-0.00", "0.00")
+            ? toEuros(expenseAmounts[user.Id])
             : "0.00€";
           return (
             <tr key={user.Id}>

--- a/billchop-fe/src/components/GroupTable.tsx
+++ b/billchop-fe/src/components/GroupTable.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import Table from "react-bootstrap/Table";
 import UserContext from "../backend/helpers/UserContext";
 import Group from "../backend/models/Group";
+import toEuros from "../util/Currency";
 import Dictionary from "../util/Dictionary";
 
 export interface IGroupTableProps {
@@ -48,8 +49,8 @@ export default class GroupTable extends React.Component<IGroupTableProps> {
       groupUsers.sort((user) => user.Id === currentUserId ? -1 : 0)
         .map((user) => {
           const expense = expenseAmounts[user.Id]
-            ? expenseAmounts[user.Id].toFixed(2).replace("-0.00", "0.00")
-            : "0.00";
+            ? toEuros(expenseAmounts[user.Id]).replace("-0.00", "0.00")
+            : "0.00€";
           return (
             <tr key={user.Id}>
               <td>{user.Id === UserContext.authenticatedUser.Id ? "You" : user.Name} {user.Id === loanerId && "(Payer)"}</td>

--- a/billchop-fe/src/components/OutsideClickListener.tsx
+++ b/billchop-fe/src/components/OutsideClickListener.tsx
@@ -27,7 +27,6 @@ const OutsideClickListener: React.FunctionComponent<IOutsideClickListenerProps> 
   );
 
   useEffect(() => {
-
     document.addEventListener("click", clickListener);
     document.addEventListener("keyup", escapeListener);
 

--- a/billchop-fe/src/pages/GroupSubPage.tsx
+++ b/billchop-fe/src/pages/GroupSubPage.tsx
@@ -9,7 +9,7 @@ import Loan from "../backend/models/Loan";
 import BillsListAccordion from "../components/BillsListAccordion";
 import GroupPageHeader from "../components/GroupPageHeader";
 import GroupTable from "../components/GroupTable";
-import MonthlySpendingGraph, { IBarChartDataset } from "../components/BarChart";
+import BarChart, { IBarChartDataset } from "../components/BarChart";
 import Dictionary from "../util/Dictionary";
 import getMonthName from "../util/Months";
 import UserContext from "../backend/helpers/UserContext";
@@ -178,7 +178,7 @@ export default class GroupSubPage extends React.Component<
             />
           </Col>
           <Col>
-            <MonthlySpendingGraph
+            <BarChart
               datasets={this.getRecentGroupSpendingDatasets()}
               headingText="Total group spending"
             />

--- a/billchop-fe/src/util/Currency.ts
+++ b/billchop-fe/src/util/Currency.ts
@@ -1,0 +1,5 @@
+const toEuros = (amount: number): string => {
+  return `${amount.toFixed(2)}€`;
+};
+
+export default toEuros;

--- a/billchop-fe/src/util/Currency.ts
+++ b/billchop-fe/src/util/Currency.ts
@@ -1,5 +1,5 @@
 const toEuros = (amount: number): string => {
-  return `${amount.toFixed(2)}€`;
+  return `${amount.toFixed(2)}€`.replace("-0.00", "0.00");
 };
 
 export default toEuros;


### PR DESCRIPTION
- Show paying user, by writing **(Payer)** next to user's name
- Order table in a way, so current user is on top of the list
- Instead of writing current user's name in group table row, now **You** is written instead
- Add € symbol, where expense amounts are shown
- Make bill name bold in table header
![image](https://user-images.githubusercontent.com/29150754/99901778-8660e100-2cb9-11eb-9ca7-5ebd61b5d60c.png)
