### PR TITLE
Fixed problem where sort was trying to sort immutable array

### DIFF
--- a/billchop-fe/src/components/GroupTable.tsx
+++ b/billchop-fe/src/components/GroupTable.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import Table from "react-bootstrap/Table";
 import UserContext from "../backend/helpers/UserContext";
 import Group from "../backend/models/Group";
+import User from "../backend/models/User";
 import toEuros from "../util/Currency";
 import Dictionary from "../util/Dictionary";
 
@@ -13,30 +14,46 @@ export interface IGroupTableProps {
   loanerId?: string;
 }
 
-export default class GroupTable extends React.Component<IGroupTableProps> {
-  getExpenseStyling(
-    expense: number | undefined | null,
-  ): React.CSSProperties | undefined {
-    const { colorCode } = this.props;
+function GroupTableRow(props: {
+  user: User, 
+  expenseAmounts: Dictionary<number>, 
+  colorCode?: boolean, 
+  loanerId?: string,
+}) {
+  const {user, expenseAmounts, colorCode, loanerId} = props;
 
+  function getExpenseStyling(expense: number | undefined | null): React.CSSProperties | undefined {
     if (!colorCode || !expense || (expense > -0.01 && expense < 0.01))
       return undefined;
 
-    if (expense > 0) return { color: "green" };
+    if (expense > 0) 
+      return { color: "green" };
 
     return { color: "red" };
   }
 
+  const expense = expenseAmounts[user.Id] ? toEuros(expenseAmounts[user.Id]) : "0.00€";
+  return (
+    <tr>
+      <td>{user.Id === UserContext.authenticatedUser.Id ? "You" : user.Name} {user.Id === loanerId && "(Payer)"}</td>
+      <td style={getExpenseStyling(expenseAmounts[user.Id])}>
+        {expense}
+      </td>
+    </tr>
+  );
+}
+
+export default class GroupTable extends React.Component<IGroupTableProps> {
   renderTableContent = (): React.ReactNode => {
-    const tableContent = [];
     const {
       group,
       expenseAmounts,
       showMembersOnlyWithExpenses,
       loanerId,
+      colorCode,
     } = this.props;
 
-    let groupUsers = group.Users;
+    let groupUsers = [...group.Users];
     const currentUserId = UserContext.authenticatedUser.Id;
 
     if (showMembersOnlyWithExpenses && expenseAmounts !== undefined) {
@@ -45,23 +62,17 @@ export default class GroupTable extends React.Component<IGroupTableProps> {
       });
     }
 
-    tableContent.push(
-      groupUsers.sort((user) => user.Id === currentUserId ? -1 : 0)
-        .map((user) => {
-          const expense = expenseAmounts[user.Id]
-            ? toEuros(expenseAmounts[user.Id])
-            : "0.00€";
-          return (
-            <tr key={user.Id}>
-              <td>{user.Id === UserContext.authenticatedUser.Id ? "You" : user.Name} {user.Id === loanerId && "(Payer)"}</td>
-              <td style={this.getExpenseStyling(expenseAmounts[user.Id])}>
-                {expense}
-              </td>
-            </tr>
-          );
-        }),
-    );
-    return tableContent;
+    return groupUsers
+      .sort((user) => user.Id === currentUserId ? -1 : 0)
+      .map((user) => (
+        <GroupTableRow 
+          key={user.Id} 
+          user={user}
+          expenseAmounts={expenseAmounts}
+          colorCode={colorCode}
+          loanerId={loanerId}
+        />),
+      );
   };
 
   render(): JSX.Element {


### PR DESCRIPTION
Fixed bug where sort was trying to sort users in group, but the users array was immutable for some reason (probably modified by immer at some point).

Fix - create copy of the array.

Other changes:
  - Extracted group table row into a stateless functional component in the same file. I chose to keep it in the same file, because they are closely related and the Row probably won't be used anywhere else besides the table.