### PR TITLE
Improvement/settle-up-sub-page

### DIFF
--- a/billchop-fe/src/assets/done-icon.svg
+++ b/billchop-fe/src/assets/done-icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black" width="48px" height="48px"><path d="M0 0h24v24H0z" fill="none"/><path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"/></svg>

--- a/billchop-fe/src/components/SettleUpSlider.tsx
+++ b/billchop-fe/src/components/SettleUpSlider.tsx
@@ -32,7 +32,9 @@ export default class SettleUpSlider extends React.Component<
     this.setState({ settleAmount: parseFloat(event.currentTarget.value) });
   };
 
-  handleSettle = (): void => {
+  handleSettle = (event: React.FormEvent<HTMLFormElement>): void => {
+    event.stopPropagation();
+    event.preventDefault();
     const { loanToSettle, onSettle } = this.props;
     const { settleAmount } = this.state;
     onSettle(loanToSettle.Id, settleAmount);

--- a/billchop-fe/src/components/SettleUpSlider.tsx
+++ b/billchop-fe/src/components/SettleUpSlider.tsx
@@ -4,9 +4,12 @@ import CurrencyInput from "./CurrencyInput";
 import "../styles/settle-up-slider.css";
 
 export interface ISettleUpSliderProps {
-  loanerName: string;
-  loanAmount: number;
-  onSettle: () => void;
+  loanToSettle: { // [TM] NOTE this is just a draft object, when implementing new model in BE feel free to change it however you seem fit.
+    Id: string;
+    loanerName: string;
+    amountToSettle: number;
+  };
+  onSettle: (Id: string, settleAmount: number) => void;
 }
 
 interface ISettleUpSliderState {
@@ -30,12 +33,13 @@ export default class SettleUpSlider extends React.Component<
   };
 
   handleSettle = (): void => {
-    const { onSettle } = this.props;
-    onSettle();
+    const { loanToSettle, onSettle } = this.props;
+    const { settleAmount } = this.state;
+    onSettle(loanToSettle.Id, settleAmount);
   };
 
   render(): JSX.Element {
-    const { loanerName, loanAmount} = this.props;
+    const { loanToSettle} = this.props;
     const { settleAmount } = this.state;
     return (
       <Form className="mt-4" onSubmit={this.handleSettle}>
@@ -43,13 +47,13 @@ export default class SettleUpSlider extends React.Component<
           <Form.Row>
             <Col className="ml-2 mr-2 mb-1">
               <div className="d-flex justify-content-between align-items-center">
-                <span>You owe {`${loanerName} ${loanAmount}€`}</span>
+                <span>You owe {`${loanToSettle.loanerName} ${loanToSettle.amountToSettle}€`}</span>
                 <div className="d-flex justify-content-end align-items-center">
                   <span className="mr-2">Pay:</span>
                   <CurrencyInput
                     onChange={this.handleSettleAmountChange}
                     value={settleAmount}
-                    max={loanAmount}
+                    max={loanToSettle.amountToSettle}
                   />
                 </div>
               </div>
@@ -61,7 +65,7 @@ export default class SettleUpSlider extends React.Component<
                 style={{ cursor: "pointer" }}
                 type="range"
                 min={0}
-                max={loanAmount}
+                max={loanToSettle.amountToSettle}
                 step={0.01}
                 onChange={this.handleSettleAmountChange}
                 value={settleAmount}

--- a/billchop-fe/src/pages/GroupsPage.tsx
+++ b/billchop-fe/src/pages/GroupsPage.tsx
@@ -85,13 +85,37 @@ export default class GroupsPage extends React.Component<
     this.setState({ showSettleUp: false });
   };
 
+  getLoansToSettle = (): { // [TM] NOTE this is just a draft object, when implementing new model in BE feel free to change it however you seem fit.
+    Id: string;
+    loanerName: string;
+    amountToSettle: number;
+  }[] => {
+    return [
+      {
+        Id: "1",
+        loanerName: "Ainoras",
+        amountToSettle: 100,
+      },
+      {
+        Id: "2",
+        loanerName: "Martynas",
+        amountToSettle: 350,
+      },
+      {
+        Id: "3",
+        loanerName: "Maurice",
+        amountToSettle: 225,
+      },
+    ];
+  };
+
   render(): JSX.Element {
     const { selectedGroupId, showSettleUp } = this.state;
     const { groups } = this.state;
     const selectedGroup = groups.find((group) => group.Id === selectedGroupId);
     return (
       <Row className="h-100">
-        <Col className="p-0 border-right" md={2}>
+        <Col className="p-0 border-right" sm={2}>
           <Sidebar
             sidebarTabs={this.getGroupsSidebarTabs()}
             onTabClick={this.handleOnGroupTabSelect}
@@ -103,6 +127,8 @@ export default class GroupsPage extends React.Component<
               <SettleUpSubPage
                 onCloseSettleUp={this.handleCloseSettleUp}
                 onSettle={this.handleCloseSettleUp}
+                // loansToSettle={this.getLoansToSettle()}
+                loansToSettle={[]}
               />
               :
               (

--- a/billchop-fe/src/pages/GroupsPage.tsx
+++ b/billchop-fe/src/pages/GroupsPage.tsx
@@ -85,30 +85,6 @@ export default class GroupsPage extends React.Component<
     this.setState({ showSettleUp: false });
   };
 
-  getLoansToSettle = (): { // [TM] NOTE this is just a draft object, when implementing new model in BE feel free to change it however you seem fit.
-    Id: string;
-    loanerName: string;
-    amountToSettle: number;
-  }[] => {
-    return [
-      {
-        Id: "1",
-        loanerName: "Ainoras",
-        amountToSettle: 100,
-      },
-      {
-        Id: "2",
-        loanerName: "Martynas",
-        amountToSettle: 350,
-      },
-      {
-        Id: "3",
-        loanerName: "Maurice",
-        amountToSettle: 225,
-      },
-    ];
-  };
-
   render(): JSX.Element {
     const { selectedGroupId, showSettleUp } = this.state;
     const { groups } = this.state;
@@ -126,8 +102,6 @@ export default class GroupsPage extends React.Component<
             showSettleUp ?
               <SettleUpSubPage
                 onCloseSettleUp={this.handleCloseSettleUp}
-                onSettle={this.handleCloseSettleUp}
-                loansToSettle={this.getLoansToSettle()}
               />
               :
               (

--- a/billchop-fe/src/pages/GroupsPage.tsx
+++ b/billchop-fe/src/pages/GroupsPage.tsx
@@ -127,8 +127,7 @@ export default class GroupsPage extends React.Component<
               <SettleUpSubPage
                 onCloseSettleUp={this.handleCloseSettleUp}
                 onSettle={this.handleCloseSettleUp}
-                // loansToSettle={this.getLoansToSettle()}
-                loansToSettle={[]}
+                loansToSettle={this.getLoansToSettle()}
               />
               :
               (

--- a/billchop-fe/src/pages/NoGroupSelectedSubPage.tsx
+++ b/billchop-fe/src/pages/NoGroupSelectedSubPage.tsx
@@ -7,7 +7,7 @@ export default class NoGroupSelectedSubPage extends React.Component {
     return (
       <div className="h-100 d-flex flex-column align-items-center justify-content-center">
         <img src={InfoIcon} height="48px" width="48px" alt="Groups icon" />
-        <p>
+        <p className="text-center m-2">
           No group selected. Please create new group or select an existing one.
         </p>
       </div>

--- a/billchop-fe/src/pages/SettleUpSubPage.tsx
+++ b/billchop-fe/src/pages/SettleUpSubPage.tsx
@@ -7,18 +7,61 @@ import "../styles/groups-page.css";
 import DoneIcon from "../assets/done-icon.svg";
 
 export interface ISettleUpSubPageProps {
+  onCloseSettleUp: () => void;
+}
+
+interface ISettleUpSubPabeState {
   loansToSettle: { // [TM] NOTE this is just a draft object, when implementing new model in BE feel free to change it however you seem fit.
     Id: string;
     loanerName: string;
     amountToSettle: number;
   }[];
-  onSettle: (Id: string, settleAmount: number) => void;
-  onCloseSettleUp: () => void;
 }
 
-export default class SettleUpSubPage extends React.Component<ISettleUpSubPageProps> {
+export default class SettleUpSubPage extends React.Component<
+  ISettleUpSubPageProps,
+  ISettleUpSubPabeState
+> {
+  constructor(props: ISettleUpSubPageProps) {
+    super(props);
+    this.state = {
+      loansToSettle: [],
+    };
+  }
+
+  componentDidMount(): void {
+    this.getLoansToSettle();
+  }
+
+  getLoansToSettle = (): void => {
+    this.setState({
+      loansToSettle: [
+        {
+          Id: "1",
+          loanerName: "Ainoras",
+          amountToSettle: 100,
+        },
+        {
+          Id: "2",
+          loanerName: "Martynas",
+          amountToSettle: 350,
+        },
+        {
+          Id: "3",
+          loanerName: "Maurice",
+          amountToSettle: 225,
+        },
+      ],
+    });
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  handleSettle = (Id: string, settleAmount: number): void => {
+    //TODO call BE
+  };
+
   renderSettleUpSliders = (): JSX.Element => {
-    const { onSettle, loansToSettle } = this.props;
+    const { loansToSettle } = this.state;
 
     return (
       <Col className="settle-up-subpage__sliders">
@@ -27,7 +70,7 @@ export default class SettleUpSubPage extends React.Component<ISettleUpSubPagePro
             return <SettleUpSlider
               key={loan.Id}
               loanToSettle={loan}
-              onSettle={onSettle}
+              onSettle={this.handleSettle}
             />;
           })
         }
@@ -55,7 +98,8 @@ export default class SettleUpSubPage extends React.Component<ISettleUpSubPagePro
   };
 
   render(): JSX.Element {
-    const { loansToSettle, onCloseSettleUp } = this.props;
+    const { onCloseSettleUp } = this.props;
+    const { loansToSettle } = this.state;
 
     return (
       <div className="h-100 w-100 subpage-container">

--- a/billchop-fe/src/pages/SettleUpSubPage.tsx
+++ b/billchop-fe/src/pages/SettleUpSubPage.tsx
@@ -35,7 +35,7 @@ export default class SettleUpSubPage extends React.Component<ISettleUpSubPagePro
     );
   };
 
-  renderInfoMessage = (): JSX.Element => {
+  renderInfoModal = (): JSX.Element => {
     const { onCloseSettleUp } = this.props;
     return (
       <Modal show centered onHide={onCloseSettleUp}>
@@ -61,7 +61,7 @@ export default class SettleUpSubPage extends React.Component<ISettleUpSubPagePro
       <div className="h-100 w-100 subpage-container">
         {
           loansToSettle.length === 0 ? 
-            this.renderInfoMessage()
+            this.renderInfoModal()
             :
             <div>
               <Row>

--- a/billchop-fe/src/pages/SettleUpSubPage.tsx
+++ b/billchop-fe/src/pages/SettleUpSubPage.tsx
@@ -4,51 +4,50 @@ import ArrowBackIcon from "../assets/arrow-back-icon.svg";
 import ImageButton from "../components/ImageButton";
 import SettleUpSlider from "../components/SettleUpSlider";
 import "../styles/groups-page.css";
+import DoneIcon from "../assets/done-icon.svg";
 
 export interface ISettleUpSubPageProps {
-  onSettle: () => void;
+  loansToSettle: { // [TM] NOTE this is just a draft object, when implementing new model in BE feel free to change it however you seem fit.
+    Id: string;
+    loanerName: string;
+    amountToSettle: number;
+  }[];
+  onSettle: (Id: string, settleAmount: number) => void;
   onCloseSettleUp: () => void;
 }
 
 export default class SettleUpSubPage extends React.Component<ISettleUpSubPageProps> {
-  renderSettleUpSliders = (): JSX.Element[] => {
-    const { onSettle } = this.props;
+  renderSettleUpSliders = (): JSX.Element => {
+    const { onSettle, loansToSettle } = this.props;
 
-    return [
-      <SettleUpSlider
-        key="1"
-        loanerName="Ainoras"
-        loanAmount={100}
-        onSettle={onSettle}
-      />,
-      <SettleUpSlider
-        key="2"
-        loanerName="Martynas"
-        loanAmount={360}
-        onSettle={onSettle}
-      />,
-      <SettleUpSlider
-        key="3"
-        loanerName="Daniel"
-        loanAmount={500}
-        onSettle={onSettle}
-      />,
-      <SettleUpSlider
-        key="4"
-        loanerName="Henrik"
-        loanAmount={500}
-        onSettle={onSettle}
-      />,<SettleUpSlider
-        key="5"
-        loanerName="Tibor"
-        loanAmount={500}
-        onSettle={onSettle}
-      />,
-    ];
+    return (
+      <Col className="settle-up-subpage__sliders">
+        {
+          loansToSettle.map((loan) => {
+            return <SettleUpSlider
+              key={loan.Id}
+              loanToSettle={loan}
+              onSettle={onSettle}
+            />;
+          })
+        }
+      </Col>
+    );
+  };
+
+  renderInfoMessage = (): JSX.Element => {
+    return (
+      <Col className="d-flex flex-column align-items-center justify-content-center">
+        <img src={DoneIcon} height="48px" width="48px" alt="Groups icon" />
+        <p className="text-center m-2">
+          All loans are settled up.
+        </p>
+      </Col>
+    );
   };
 
   render(): JSX.Element {
-    const { onCloseSettleUp } = this.props;
+    const { loansToSettle, onCloseSettleUp } = this.props;
 
     return (
       <div className="h-100 w-100 subpage-container">
@@ -57,10 +56,8 @@ export default class SettleUpSubPage extends React.Component<ISettleUpSubPagePro
             <ImageButton imageSource={ArrowBackIcon} tooltipText="Go back" onClick={onCloseSettleUp} />
           </Col>
         </Row>
-        <Row>
-          <Col className="settle-up-subpage__sliders">
-            {this.renderSettleUpSliders()}
-          </Col>
+        <Row className="h-100">
+          {loansToSettle.length === 0 ? this.renderInfoMessage() : this.renderSettleUpSliders()}
         </Row>
       </div>
     );

--- a/billchop-fe/src/pages/SettleUpSubPage.tsx
+++ b/billchop-fe/src/pages/SettleUpSubPage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Col, Row } from "react-bootstrap";
+import { Button, Col, Modal, Row } from "react-bootstrap";
 import ArrowBackIcon from "../assets/arrow-back-icon.svg";
 import ImageButton from "../components/ImageButton";
 import SettleUpSlider from "../components/SettleUpSlider";
@@ -36,13 +36,21 @@ export default class SettleUpSubPage extends React.Component<ISettleUpSubPagePro
   };
 
   renderInfoMessage = (): JSX.Element => {
+    const { onCloseSettleUp } = this.props;
     return (
-      <Col className="d-flex flex-column align-items-center justify-content-center">
-        <img src={DoneIcon} height="48px" width="48px" alt="Groups icon" />
-        <p className="text-center m-2">
-          All loans are settled up.
-        </p>
-      </Col>
+      <Modal show centered onHide={onCloseSettleUp}>
+        <Modal.Body className="d-flex flex-column align-items-center justify-content-center">
+          <img src={DoneIcon} height="48px" width="48px" alt="Groups icon" />
+          <p className="text-center m-2">
+            All loans are settled up.
+          </p>
+        </Modal.Body>
+        <Modal.Footer className="justify-content-center">
+          <Button variant="primary" onClick={onCloseSettleUp}>
+            Close
+          </Button>
+        </Modal.Footer>
+      </Modal>
     );
   };
 
@@ -51,14 +59,21 @@ export default class SettleUpSubPage extends React.Component<ISettleUpSubPagePro
 
     return (
       <div className="h-100 w-100 subpage-container">
-        <Row>
-          <Col>
-            <ImageButton imageSource={ArrowBackIcon} tooltipText="Go back" onClick={onCloseSettleUp} />
-          </Col>
-        </Row>
-        <Row className="h-100">
-          {loansToSettle.length === 0 ? this.renderInfoMessage() : this.renderSettleUpSliders()}
-        </Row>
+        {
+          loansToSettle.length === 0 ? 
+            this.renderInfoMessage()
+            :
+            <div>
+              <Row>
+                <Col>
+                  <ImageButton imageSource={ArrowBackIcon} tooltipText="Go back" onClick={onCloseSettleUp} />
+                </Col>
+              </Row>
+              <Row>
+                {this.renderSettleUpSliders()}
+              </Row>
+            </div>
+        }
       </div>
     );
   }


### PR DESCRIPTION
Added info modal in SettleUpSubPage which is shown, when there are no loans to settle.
At first I wanted to show an empty subpage with a message, like in NoGroupSelectedSubPage, but found some layout issues on mobile devices, so for now modal is shown.
![image](https://user-images.githubusercontent.com/29150754/101044669-e9872900-357f-11eb-9133-7c15cf823a97.png)
